### PR TITLE
bug; changed number ids to string, name to title

### DIFF
--- a/apps/micro/src/app/home/home.component.spec.ts
+++ b/apps/micro/src/app/home/home.component.spec.ts
@@ -63,7 +63,7 @@ describe('HomeComponent', () => {
     let widgets = [];
     const widget = {
       id: null,
-      name: 'new item',
+      title: 'new item',
       description: 'new item',
       price: 100,
     };
@@ -77,11 +77,11 @@ describe('HomeComponent', () => {
 
   it('should update a widget on updateWidget', () => {
     let widgets = [
-      { id: 100, name: 'new item', description: 'new item', price: 100 },
+      { id: '100', title: 'new item', description: 'new item', price: 100 },
     ];
     const widget = {
-      id: 100,
-      name: 'UPDATED',
+      id: '100',
+      title: 'UPDATED',
       description: 'WIDGET',
       price: 100,
     };
@@ -93,11 +93,11 @@ describe('HomeComponent', () => {
 
   it('should delete a widget on deleteWidget', () => {
     let widgets = [
-      { id: 100, name: 'new item', description: 'new item', price: 100 },
+      { id: '100', title: 'new item', description: 'new item', price: 100 },
     ];
     const widget = {
-      id: 100,
-      name: 'new item',
+      id: '100',
+      title: 'new item',
       description: 'new item',
       price: 100,
     };


### PR DESCRIPTION
The changes to id and name were made to adhere to the Widget interface:
```
export interface BaseEntity {
  id: string | null;
}

export interface Widget extends BaseEntity {
  title: string;
  description: string;
  price: number;
}
```